### PR TITLE
feat: support workspaceFolder var and link surrounded by symbols

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "path-mapper",
-  "version": "0.0.1",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "path-mapper",
-      "version": "0.0.1",
+      "version": "0.0.8",
       "devDependencies": {
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/thruthesky/path-mapper"
   },
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "vscode": "^1.79.0"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,6 @@ export function activate(context: vscode.ExtensionContext) {
 			console.log('--> getAbsolutePath(link.data)');
 
 			let mapper: Array<{ match: string, replace: string }> = vscode.workspace.getConfiguration().get('path-mapper') ?? [];
-			console.log('mapper: ', mapper);
 			// Resolve workspaceFolder variable
 			mapper = mapper.map((e) => {
 				return {
@@ -77,7 +76,6 @@ export function activate(context: vscode.ExtensionContext) {
 					replace: e.replace.replace(/\${workspaceFolder}/g, workspaceFolder)
 				};
 			});
-			console.log('mapper: ', mapper);
 
 			// console.log('mapper[0]: ', mapper[0]);
 			// console.log('mapper[1]: ', mapper[1]);


### PR DESCRIPTION
This PR adds supports for links in the form of:

```
'/my/path'
"/my/path"
[/my/path]
(/my/path)
('/my/path')
[("/my/path")]
etc
```

as well as using the `workspaceFolder` variable in settings